### PR TITLE
Add support for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pip-log.txt
 
 # unit test / coverage reports
 .coverage
+.tox
 
 # sphnix
 docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, pypy
+
+[testenv]
+commands = nosetests
+deps =
+    nose
+    mock


### PR DESCRIPTION
Output of tox:

```
[last: 0] marca@SCML-MarcA:~/dev/git-repos/wac$ tox
GLOB sdist-make: /Users/marca/dev/git-repos/wac/setup.py
py26 sdist-reinst: /Users/marca/dev/git-repos/wac/.tox/dist/wac-0.6.zip
py26 runtests: commands[0]
EEE.EE......E...E...EE.....E....EE..EE..EE..E...
======================================================================
ERROR: test_config_context (tests.TestClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/tests.py", line 268, in test_config_context
    self.assertIn('X-Custom', self.cli.config.headers)
AttributeError: 'TestClient' object has no attribute 'assertIn'

======================================================================
ERROR: test_custom_errors (tests.TestClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 344, in test_custom_errors
    with self.assertRaises(ErrorType1) as exc:
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_default_errors (tests.TestClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 291, in test_default_errors
    with self.assertRaises(wac.Error) as exc:
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_deserialize (tests.TestClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 250, in test_deserialize
    with self.assertRaises(Exception) as ex_ctx:
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_exception_request_handlers (tests.TestClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 403, in test_exception_request_handlers
    with self.assertRaises(wac.Error) as ex_ctx:
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_request_handlers (tests.TestClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 381, in test_request_handlers
    self.assertDictEqual(result.data, {'bye': 'ya'})
AttributeError: 'TestClient' object has no attribute 'assertDictEqual'

======================================================================
ERROR: test_fetch (tests.TestPage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 469, in test_fetch
    self.assertItemsEqual(
AttributeError: 'TestPage' object has no attribute 'assertItemsEqual'

======================================================================
ERROR: test_first (tests.TestPagination)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 730, in test_first
    with self.assertRaises(wac.MultipleResultsFound):
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_index (tests.TestPagination)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 661, in test_index
    with self.assertRaises(IndexError):
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_filter (tests.TestQuery)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/tests.py", line 761, in test_filter
    q.filter(Resource1.f.a == 'b')
  File "/Users/marca/dev/git-repos/wac/wac.py", line 862, in filter
    f = '{}'.format(expression.field.name)
ValueError: zero length field name in format

======================================================================
ERROR: test_one (tests.TestQuery)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 837, in test_one
    with self.assertRaises(wac.NoResultFound):
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_one_cached (tests.TestQuery)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 871, in test_one_cached
    with self.assertRaises(wac.NoResultFound):
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_sort (tests.TestQuery)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/tests.py", line 794, in test_sort
    q.sort(Resource1.f.me.asc())
  File "/Users/marca/dev/git-repos/wac/wac.py", line 885, in sort
    'asc' if expression.ascending else 'desc')
ValueError: zero length field name in format

======================================================================
ERROR: test_create_from_save (tests.TestResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 1134, in test_create_from_save
    self.assertDictEqual(_op.call_args[1]['headers'], {
AttributeError: 'TestResource' object has no attribute 'assertDictEqual'

======================================================================
ERROR: test_objectify (tests.TestResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/tests.py", line 1113, in test_objectify
    self._objectify_equal(o)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 1065, in _objectify_equal
    self.assertItemsEqual(
AttributeError: 'TestResource' object has no attribute 'assertItemsEqual'

======================================================================
ERROR: test_objectify_uris (tests.TestResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 1189, in test_objectify_uris
    with self.assertRaises(AttributeError):
TypeError: failUnlessRaises() takes at least 3 arguments (2 given)

======================================================================
ERROR: test_save_objectify (tests.TestResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/py26/lib/python2.6/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 1166, in test_save_objectify
    self._objectify_equal(r)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 1065, in _objectify_equal
    self.assertItemsEqual(
AttributeError: 'TestResource' object has no attribute 'assertItemsEqual'

----------------------------------------------------------------------
Ran 48 tests in 1.326s

FAILED (errors=17)
ERROR: InvocationError: '/Users/marca/dev/git-repos/wac/.tox/py26/bin/nosetests'
py27 sdist-reinst: /Users/marca/dev/git-repos/wac/.tox/dist/wac-0.6.zip
py27 runtests: commands[0]
................................................
----------------------------------------------------------------------
Ran 48 tests in 0.967s

OK
pypy sdist-reinst: /Users/marca/dev/git-repos/wac/.tox/dist/wac-0.6.zip
pypy runtests: commands[0]
.....................................F..........
======================================================================
FAIL: test_create_from_save (tests.TestResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/wac/.tox/pypy/site-packages/mock.py", line 1224, in patched
    return func(*args, **keywargs)
  File "/Users/marca/dev/git-repos/wac/tests.py", line 1133, in test_create_from_save
    self.assertEqual(_op.call_args[1].keys(), ['headers', 'data'])
AssertionError: Lists differ: ['data', 'headers'] != [u'headers', u'data']

First differing element 0:
data
headers

- ['data', 'headers']
+ [u'headers', u'data']

----------------------------------------------------------------------
Ran 48 tests in 21.230s

FAILED (failures=1)
ERROR: InvocationError: '/Users/marca/dev/git-repos/wac/.tox/pypy/bin/nosetests'
_________________________________________________________________________ summary __________________________________________________________________________
ERROR:   py26: commands failed
  py27: commands succeeded
ERROR:   pypy: commands failed
```
