### PR TITLE
Fiter

### DIFF
--- a/wac.py
+++ b/wac.py
@@ -1307,7 +1307,7 @@ class ResourceCollection(PaginationMixin):
 
     def filter(self, *args, **kwargs):
         q = Query(self.resource, self.uri, self.pagination.size)
-        q.fiter(*args, **kwargs)
+        q.filter(*args, **kwargs)
         return q
 
     def sort(self, *args):


### PR DESCRIPTION
Also getting a funky message when going to run unittests:

```
(wac)[marshall@marshall@12/10/02,09:14:~/code/mjallday/wac](master)
% python setup.py test
running test
Searching for unitest2>=0.5.1
Reading http://pypi.python.org/simple/unitest2/
Couldn't find index page for 'unitest2' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading http://pypi.python.org/simple/
No local packages or download links found for unitest2>=0.5.1
Best match: None
Traceback (most recent call last):
  File "setup.py", line 49, in <module>
    'Programming Language :: Python :: 2.7',
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/setuptools/command/test.py", line 113, in run
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/setuptools/dist.py", line 284, in fetch_build_eggs
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/pkg_resources.py", line 563, in resolve
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/pkg_resources.py", line 799, in best_match
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/pkg_resources.py", line 811, in obtain
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/setuptools/dist.py", line 327, in fetch_build_egg
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/setuptools/command/easy_install.py", line 434, in easy_install
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/setuptools/package_index.py", line 475, in fetch_distribution
AttributeError: 'NoneType' object has no attribute 'clone'
```

Or running `nosetests` directly

```
(wac)[marshall@marshall@12/10/02,09:14:~/code/mjallday/wac](master)
% nosetests
E
======================================================================
ERROR: Failure: ImportError (No module named unittest2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/nose/loader.py", line 390, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/nose/importer.py", line 39, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/marshall/.virtualenvs/wac/lib/python2.7/site-packages/nose/importer.py", line 86, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/marshall/code/mjallday/wac/tests.py", line 6, in <module>
    import unittest2 as unittest
ImportError: No module named unittest2

----------------------------------------------------------------------
Ran 1 test in 0.026s

FAILED (errors=1)
```
