### PR TITLE
python3 support

### DIFF
--- a/example.py
+++ b/example.py
@@ -46,7 +46,7 @@ class Client(wac.Client):
     def _op(self, *args, **kwargs):
         try:
             return super(Client, self)._op(*args, **kwargs)
-        except wac.Error, ex:
+        except wac.Error as ex:
             raise self._convert_exception(ex)
 
     @staticmethod
@@ -82,8 +82,8 @@ class Client(wac.Client):
     @staticmethod
     def _parse_deserialized(e):
         if isinstance(e, dict):
-            for key in e.iterkeys():
-                if key.endswith('_at') and isinstance(e[key], basestring):
+            for key in e.keys():
+                if key.endswith('_at') and isinstance(e[key], str):
                     e[key] = iso8601.parse_date(e[key])
         return e
 
@@ -92,12 +92,12 @@ class Error(Exception):
 
     def __init__(self, *args, **kwargs):
         super(Error, self).__init__(*args)
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
     def __repr__(self):
         attrs = ', '.join(['{}={}'.format(k, repr(v))
-                           for k, v in self.__dict__.iteritems()])
+                           for k, v in self.__dict__.items()])
         return '{}({}, {})'.format(
             self.__class__.__name__,
             ' '.join(self.args),

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     tests_require=[
         'mock>=0.8',
         'simplejson >= 2.1',
-        'unittest2py3k >= 0.5.1',
+        'unittest2 >= 0.5.1',
         'iso8601',
     ],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     tests_require=[
         'mock>=0.8',
         'simplejson >= 2.1',
-        'unittest2 >= 0.5.1',
+        'unittest2py3k >= 0.5.1',
         'iso8601',
     ],
     install_requires=[

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,7 @@ import imp
 import json
 import os
 import math
-import unittest2py3k as unittest
+import unittest2 as unittest
 import urllib.request, urllib.parse, urllib.error
 
 from mock import Mock, patch

--- a/tests.py
+++ b/tests.py
@@ -567,7 +567,7 @@ class TestPage(TestCase):
             }
             data.update(common_data)
             _op.return_value.data = data
-            link = page.__next__
+            link = page.next
             self.assertEqual(link.uri, '/a/uri/next')
             self.assertEqual(link.resource_cls, page.resource_cls)
 
@@ -602,7 +602,7 @@ class TestPage(TestCase):
             link = page.previous
             self.assertEqual(link, None)
 
-            link = page.__next__
+            link = page.next
             self.assertEqual(link, None)
 
             data['uri'] = '/a/uri/last'

--- a/tests.py
+++ b/tests.py
@@ -568,7 +568,7 @@ class TestPage(TestCase):
             }
             data.update(common_data)
             _op.return_value.data = data
-            link = page.__next__
+            link = next(page)
             self.assertEqual(link.uri, '/a/uri/next')
             self.assertEqual(link.resource_cls, page.resource_cls)
 
@@ -603,7 +603,7 @@ class TestPage(TestCase):
             link = page.previous
             self.assertEqual(link, None)
 
-            link = page.__next__
+            link = next(page)
             self.assertEqual(link, None)
 
             data['uri'] = '/a/uri/last'

--- a/tests.py
+++ b/tests.py
@@ -1,12 +1,12 @@
 
 
 
-import imp
 import json
 import os
 import math
 import unittest2 as unittest
 import urllib.request, urllib.parse, urllib.error
+import importlib
 
 from mock import Mock, patch
 
@@ -1421,4 +1421,5 @@ class TestExample(TestCase):
         path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), 'example.py')
         )
+        
         importlib.machinery.SourceFileLoader('example', path).load_module()

--- a/tests.py
+++ b/tests.py
@@ -1421,4 +1421,4 @@ class TestExample(TestCase):
         path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), 'example.py')
         )
-        imp.load_source('example', path)
+        importlib.machinery.SourceFileLoader('example', path).load_module()

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,7 @@ import imp
 import json
 import os
 import math
-import unittest2 as unittest
+import unittest2py3k as unittest
 import urllib.request, urllib.parse, urllib.error
 
 from mock import Mock, patch

--- a/tests.py
+++ b/tests.py
@@ -1241,7 +1241,7 @@ class TestResource(TestCase):
             Resource1.get('/v2/1s')
         self.assertIn(
             'Resource1 type "one" does not match "page"',
-            ex_ctx.exception)
+            str(ex_ctx.exception))
 
     @patch('wac.Client._op')
     def test_get_collection_lookup_failure(self, _op):
@@ -1265,7 +1265,7 @@ class TestResource(TestCase):
             Resource1.get('/v2/2s/id')
         self.assertIn(
             'Resource1 type "one" does not match "two"',
-            ex_ctx.exception)
+            str(ex_ctx.exception))
 
     @patch('wac.Client._op')
     def test_get_member_base(self, _op):

--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,6 @@ import math
 import unittest2 as unittest
 import urllib.request, urllib.parse, urllib.error
 import importlib
-
 from mock import Mock, patch
 
 import wac
@@ -568,7 +567,7 @@ class TestPage(TestCase):
             }
             data.update(common_data)
             _op.return_value.data = data
-            link = next(page)
+            link = page.__next__
             self.assertEqual(link.uri, '/a/uri/next')
             self.assertEqual(link.resource_cls, page.resource_cls)
 
@@ -603,7 +602,7 @@ class TestPage(TestCase):
             link = page.previous
             self.assertEqual(link, None)
 
-            link = next(page)
+            link = page.__next__
             self.assertEqual(link, None)
 
             data['uri'] = '/a/uri/last'

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ commands = nosetests
 deps =
     nose
     mock
-    unittest2
+    unittest2py3k

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ commands = nosetests
 deps =
     nose
     mock
-    unittest2py3k
+    unittest2

--- a/wac.py
+++ b/wac.py
@@ -712,7 +712,7 @@ class Pagination(object):
         page = self.current
         while True:
             yield page
-            page = page.__next__
+            page = next(page)
             if not page:
                 break
             self._current = page

--- a/wac.py
+++ b/wac.py
@@ -712,7 +712,7 @@ class Pagination(object):
         page = self.current
         while True:
             yield page
-            page = next(page)
+            page = page.__next__
             if not page:
                 break
             self._current = page

--- a/wac.py
+++ b/wac.py
@@ -703,16 +703,16 @@ class Pagination(object):
         return self._current
 
     def __next__(self):
-        if not self.current.__next__:
+        if not self.current.next:
             return None
-        self._current = self._current.__next__
+        self._current = self._current.next
         return self._current
 
     def __iter__(self):
         page = self.current
         while True:
             yield page
-            page = page.__next__
+            page = page.next
             if not page:
                 break
             self._current = page

--- a/wac.py
+++ b/wac.py
@@ -14,7 +14,7 @@ import urllib.parse
 
 import requests
 
-__version__ = '0.22'
+__version__ = '0.23'
 
 __all__ = [
     'Config',


### PR DESCRIPTION
I ported wac over to python3, however this port has no backwards compatibility so it won't support python2. It passes all test cases besides test_parse_uri and I'm not too sure why at the moment. I only spent the past 2 hours or so porting this so I am not familiar enough with the code yet to figure it out. I will look more into it later.
