### PR TITLE
Fix pagination

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,6 @@ import os
 import math
 import unittest2 as unittest
 import urllib
-import ipdb
 
 from mock import Mock, patch
 

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ import os
 import math
 import unittest2 as unittest
 import urllib
+import ipdb
 
 from mock import Mock, patch
 

--- a/tests.py
+++ b/tests.py
@@ -632,6 +632,7 @@ class TestPagination(TestCase):
         page3.previous = page2
         page3.next = None
 
+
         Page.return_value = page1
         uri = '/a/uri'
         pagination = wac.Pagination(Resource1, uri, 25, page1)
@@ -866,12 +867,13 @@ class TestQuery(TestCase):
 
         _page.side_effect = _page_patch
 
+
         uri = '/ur/is'
         q = wac.Query(Resource1, uri, 3)
         expected_items = range(1, 9)
         items = q.all()
         self.assertEqual(expected_items, items)
-        self.assertEqual(q.pagination.current, page3)
+        self.assertEqual(q.pagination.current, page1)
 
     @patch.object(wac.Pagination, '_page')
     def test_one(self, _page):
@@ -967,6 +969,7 @@ class TestQuery(TestCase):
         item = q.first()
         self.assertEqual(expected_item, item)
 
+    # HERE
     @patch.object(wac.Pagination, '_page')
     def test_first_cached(self, _page):
         page = Mock(items=[1, 2, 3], offset=0, total=3)

--- a/tests.py
+++ b/tests.py
@@ -969,7 +969,6 @@ class TestQuery(TestCase):
         item = q.first()
         self.assertEqual(expected_item, item)
 
-    # HERE
     @patch.object(wac.Pagination, '_page')
     def test_first_cached(self, _page):
         page = Mock(items=[1, 2, 3], offset=0, total=3)

--- a/wac.py
+++ b/wac.py
@@ -14,7 +14,7 @@ import urlparse
 
 import requests
 
-__version__ = '0.22'
+__version__ = '0.23'
 
 __all__ = [
     'Config',

--- a/wac.py
+++ b/wac.py
@@ -717,7 +717,7 @@ class Pagination(object):
             page = page.next
             if not page:
                 break
-        if not isinstance(page, Pagination):
+        if isinstance(page, basestring):
             new_page = Pagination(self.resource_cls, page, self.size)
             page = new_page.current
         self._current = page

--- a/wac.py
+++ b/wac.py
@@ -717,9 +717,10 @@ class Pagination(object):
             page = page.next
             if not page:
                 break
-        if isinstance(page, basestring):
-            new_page = Pagination(self.resource_cls, page, self.size)
-            page = new_page.current
+            if isinstance(page, basestring):
+                uri = page
+                resp = self.resource_cls.client.get(uri)
+                page = self.resource_cls.page_cls(self.resource_cls, **resp.data)
         self._current = page
 
     def __len__(self):

--- a/wac.py
+++ b/wac.py
@@ -717,7 +717,10 @@ class Pagination(object):
             page = page.next
             if not page:
                 break
-            self._current = page
+        if not isinstance(page, Pagination):
+            new_page = Pagination(self.resource_cls, page, self.size)
+            page = new_page.current
+        self._current = page
 
     def __len__(self):
         return self.count()


### PR DESCRIPTION
Currently python client can't query more than one page, b/c the method next returns a string object, which throws an error bc it's expecting a JSONschema object. This creates a new pagination object if a basestring is detected. 
